### PR TITLE
 Fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ prd.plot([prd_data_1, prd_data_2], ['model_1', 'model_2'])
 ```
 
 ## Further information
-External copyright for: [prd_score.py](https://github.com/google/compare_gan/blob/master/compare_gan/src/prd_score.py) [prd_score_test.py](https://github.com/google/compare_gan/blob/master/compare_gan/src/prd_score_test.py)
-[inception_network.py](https://github.com/google/compare_gan/blob/master/compare_gan/src/fid_score.py)<br>
+External copyright for: [prd_score.py](https://github.com/google/compare_gan/blob/master/compare_gan/metrics/prd_score.py) [prd_score_test.py](https://github.com/google/compare_gan/blob/master/compare_gan/metrics/prd_score_test.py)
+[inception_network.py](https://github.com/google/compare_gan/blob/master/compare_gan/metrics/fid_score.py)<br>
 Copyright for remaining files: [Mehdi S. M. Sajjadi](http://msajjadi.com)<br>
 
 License for all files: [Apache License 2.0](LICENSE)

--- a/inception_network.py
+++ b/inception_network.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Taken from https://github.com/google/compare_gan/blob/master/compare_gan/src/fid_score.py
+# Taken from https://github.com/google/compare_gan/blob/master/compare_gan/metrics/fid_score.py
 # Copyright 2018 Google LLC & Hwalsuk Lee.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/prd_score.py
+++ b/prd_score.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 # Taken from:
-# https://github.com/google/compare_gan/blob/master/compare_gan/src/prd_score.py
+# https://github.com/google/compare_gan/blob/master/compare_gan/metrics/prd_score.py
 #
 # Changes:
 #   - default dpi changed from 150 to 300

--- a/prd_score_test.py
+++ b/prd_score_test.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Taken from https://github.com/google/compare_gan/blob/master/compare_gan/src/prd_score_test.py
+# Taken from https://github.com/google/compare_gan/blob/master/compare_gan/metrics/prd_score_test.py
 # Copyright 2018 Google LLC & Hwalsuk Lee.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
### Summary
This PR fixes broken links to source files in the `google/compare_gan` repository across multiple files: `README.md`, `prd_score.py`, `prd_score_test.py` and `inception_network.py`. The links are updated to their new locations.

### Changes
- Updated links in `README.md`, `prd_score.py`, `prd_score_test.py` and `inception_network.py` to use the correct paths.
